### PR TITLE
Fixed kinopoisk rating vote count

### DIFF
--- a/lib/kinopoisk/movie.rb
+++ b/lib/kinopoisk/movie.rb
@@ -112,7 +112,7 @@ module Kinopoisk
 
     # Returns an integer kinopoisk rating vote count
     def rating_count
-      search_by_itemprop('ratingCount').to_i
+      search_by_itemprop('ratingCount').gsub(' ', '').to_i
     end
 
     # Returns an array of strings containing director names


### PR DESCRIPTION
Kinoposk use non-breaking space separated.
'100 500'.to_i # return 100
'100 500'.gsub(' ', '').to_i # return 100500